### PR TITLE
Add Adam's SciComp role to HTAN project for bucket access

### DIFF
--- a/config/projects-prod/htan-project.yaml
+++ b/config/projects-prod/htan-project.yaml
@@ -14,6 +14,7 @@ parameters:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/phil.snyder@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
     - 'arn:aws:sts::888810830951:assumed-role/AWSReservedSSO_Administrator_bf3b4691e22cc3c6/adam.taylor@sagebase.org' # Provides for htan-dev cross-account access
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org' # Provides access to HTAN buckets in SciComp
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'


### PR DESCRIPTION
This PR will allow my SciComp role access to the HTAN Tower project buckets to facilitate cross-account transfer into the HTNA buckets from tower

Using this route as the inverse (Adding tower viewer role in SciComp) did not work as the TowerViewer role does not have generic S3 permissions.

See PR: https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/599
And #sageit slack thread: https://sagebionetworks.slack.com/archives/CEFQD0KU1/p1692196401882069